### PR TITLE
Update traccar init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ helm repo update
 </tr>
 <tr>
 <td markdown="span"><a href="https://github.com/JeffResc/charts/tree/main/charts/traccar">traccar</a></td>
-<td markdown="span">0.1.4</td>
+<td markdown="span">0.1.5</td>
 <td markdown="span">6.7-alpine</td>
 <td markdown="span">Modern GPS Tracking Platform</td>
 </tr>

--- a/charts/traccar/Chart.yaml
+++ b/charts/traccar/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/traccar/templates/deployment.yaml
+++ b/charts/traccar/templates/deployment.yaml
@@ -43,18 +43,15 @@ spec:
           {{- end }}
           command:
             - sh
-            - -c
-            - |
-              cp /config-template/traccar.xml /config-final/traccar.xml
-              {{- range .Values.config.secrets }}
-              val=$(cat /secrets/{{ .env }}/{{ .secretKey }})
-              sed -i "s|</properties>|  <entry key='{{ .key }}'>$val</entry>\n</properties>|" /config-final/traccar.xml
-              {{- end }}
+            - /scripts/generate-traccar-config.sh
           volumeMounts:
             - name: traccar-config
               mountPath: /config-template
             - name: config-volume
               mountPath: /config-final
+            - name: init-script
+              mountPath: /scripts/generate-traccar-config.sh
+              subPath: generate-traccar-config.sh
             {{- range .Values.config.secrets }}
             - name: secret-{{ .env | lower }}
               mountPath: /secrets/{{ .env }}
@@ -98,6 +95,10 @@ spec:
         - name: traccar-config
           configMap:
             name: traccar-config
+        - name: init-script
+          configMap:
+            name: traccar-init-script
+            defaultMode: 0755
         {{- range .Values.config.secrets }}
         - name: secret-{{ .env | lower }}
           secret:

--- a/charts/traccar/templates/init-script-configmap.yaml
+++ b/charts/traccar/templates/init-script-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.initContainer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: traccar-init-script
+  labels:
+    {{- include "traccar.labels" . | nindent 4 }}
+data:
+  generate-traccar-config.sh: |-
+    #!/bin/sh
+    cp /config-template/traccar.xml /config-final/traccar.xml
+    {{- range .Values.config.secrets }}
+    val=$(cat /secrets/{{ .env }}/{{ .secretKey }})
+    sed -i "s|</properties>|  <entry key='{{ .key }}'>$val</entry>\\n</properties>|" /config-final/traccar.xml
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- move init container command into `traccar-init-script` ConfigMap
- mount script into init container and execute it
- bump traccar chart version to 0.1.5

## Testing
- `helm lint charts/traccar` *(fails: command not found)*
- `helm version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685209bff13083309ddac461a9d49032