### PR TITLE
Add README copy step in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,22 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          charts_dir: charts/
-          skip_existing: true
+        - name: Run chart-releaser
+          uses: helm/chart-releaser-action@v1.7.0
+          env:
+            CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+            charts_dir: charts/
+            skip_existing: true
+
+        - name: Copy README to gh-pages
+          run: |
+            git fetch origin gh-pages
+            git switch gh-pages
+            git checkout main -- README.md
+            if ! git diff --quiet README.md; then
+              git add README.md
+              git commit -m "Update README on gh-pages"
+              git push origin gh-pages
+            fi
+            git switch -


### PR DESCRIPTION
## Summary
- copy `README.md` to the `gh-pages` branch during release

## Testing
- `helm version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68520c9db60c8330b3c8fd751c12e658