### PR TITLE
Fix README inconsistencies and align esphome values

### DIFF
--- a/charts/13ft/README.md
+++ b/charts/13ft/README.md
@@ -84,7 +84,7 @@ helm uninstall 13ft
 | Name           | Description            | Value       |
 | -------------- | ---------------------- | ----------- |
 | `service.type` | Service type to create | `ClusterIP` |
-| `service.port` | Service port to use    | `6052`      |
+| `service.port` | Service port to use    | `5000`      |
 
 ### Ingress parameters
 
@@ -115,23 +115,8 @@ helm uninstall 13ft
 | `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage    | `80`    |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage | `80`    |
 
-### Persistence parameters
-
-| Name                       | Description                          | Value             |
-| -------------------------- | ------------------------------------ | ----------------- |
-| `persistence.enabled`      | If persistence is enabled            | `false`           |
-| `persistence.name`         | Persistent storage PVC name          | `esphome-config`  |
-| `persistence.storageClass` | Persistent storage PVC storage class | `my-storageclass` |
-| `persistence.size`         | Persistent storage PVC size          | `5Gi`             |
-
 ## Changelog
 
-### 0.1.4
-- updated default esphome container image to 2025.4.1
-
-### 0.0.2
-- Provided updated documentation
-
-### 0.0.1
+### 0.1.0
 - Initial release
 

--- a/charts/esphome/README.md
+++ b/charts/esphome/README.md
@@ -124,6 +124,18 @@ helm uninstall esphome
 | `persistence.storageClass` | Persistent storage PVC storage class | `my-storageclass` |
 | `persistence.size`         | Persistent storage PVC size          | `5Gi`             |
 
+### Extra volume mounts parameter
+
+| Name           | Description                                   | Value |
+| -------------- | --------------------------------------------- | ----- |
+| `volumeMounts` | Additional volume mounts for the main pod     | `[]`  |
+
+### Extra volumes parameter
+
+| Name    | Description                            | Value |
+| ------- | -------------------------------------- | ----- |
+| `volumes` | Provide extra volumes for the main pod | `[]`  |
+
 ## Changelog
 
 ### 0.1.4

--- a/charts/esphome/values.yaml
+++ b/charts/esphome/values.yaml
@@ -139,3 +139,16 @@ persistence:
   storageClass: "my-storageclass"
   size: "5Gi"
 
+# Additional volume mounts for the StatefulSet
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# Additional volumes for the StatefulSet
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+


### PR DESCRIPTION
## Summary
- correct `service.port` in 13ft README and clean up old persistence docs
- document extra volume options for esphome
- add missing `volumeMounts` and `volumes` defaults for esphome

## Testing
- `helm lint charts/13ft` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ed442d35c8330970915e3b579797d