### PR TITLE
fix: correct git diff check in gh-pages README workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           git fetch origin gh-pages
           git switch gh-pages
           git checkout main -- README.md
-          if ! git diff --quiet README.md; then
+          if ! git diff --quiet HEAD README.md; then
             git add README.md
             git commit -m "Update README on gh-pages"
             git push origin gh-pages


### PR DESCRIPTION
The workflow was using 'git diff --quiet README.md' which compares working directory to staging area. Since 'git checkout main -- README.md' stages the file, no diff was detected. Changed to 'git diff --quiet HEAD README.md' to properly compare against the current gh-pages HEAD.